### PR TITLE
Add "extended" class to homepage pie crust, alter legend colors to match site-wide standard

### DIFF
--- a/app/assets/scripts/views/home.js
+++ b/app/assets/scripts/views/home.js
@@ -27,7 +27,7 @@ var Home = React.createClass({
     const { projects } = this.props.api;
     const { lang } = this.props.meta;
     const categories = {};
-    const status = { ontime: 0, delayed: 0 };
+    const status = { ontime: 0, delayed: 0, extended: 0 };
     projects.forEach(function (project) {
       get(project, 'categories', []).forEach(function (category) {
         categories[category[lang]] = categories[category[lang]] + 1 || 1;
@@ -36,10 +36,12 @@ var Home = React.createClass({
       const ontime = isOntime(project);
       if (ontime === null) {
         return;
-      } else if (ontime) {
-        status.ontime += 1;
-      } else {
+      } else if (ontime === 'delayed') {
         status.delayed += 1;
+      } else if (ontime === 'extended') {
+        status.extended += 1;
+      } else {
+        status.ontime += 1;
       }
     });
 
@@ -70,6 +72,9 @@ var Home = React.createClass({
     }, {
       name: 'Delayed',
       value: status.delayed
+    }, {
+      name: 'Extended',
+      value: status.extended
     }];
 
     const t = get(window.t, [lang, 'homepage'], {});
@@ -142,6 +147,7 @@ var Home = React.createClass({
                   <div className='status-key'>
                     <p className='status-key__label status-ontime'>{t.chart_two_label}</p>
                     <p className='status-key__label status-delayed'>{t.chart_two_label2}</p>
+                    <p className='status-key__label status-extended'>{t.chart_two_label3}</p>
                   </div>
                 </div>
               </div>

--- a/app/assets/styles/components/_charts.scss
+++ b/app/assets/styles/components/_charts.scss
@@ -64,11 +64,15 @@
 }
 
 .pie__slice__on-time {
-  fill: $base-color;
+  fill: $success-color;
 }
 
 .pie__slice__delayed {
-  fill: rgba(43, 35, 66, 0.55);
+  fill: $warning-color;
+}
+
+.pie__slice__extended {
+  fill: $partial-success-color;
 }
 
 .chart__bar {
@@ -105,10 +109,13 @@
     border-radius: .15rem;
   }
   .status-ontime:before {
-    background: $base-color;
+    background: $success-color;
   }
   .status-delayed:before {
-    background: rgba(43, 35, 66, 0.55);
+    background: $warning-color;
+  }
+  .status-extended:before {
+    background: $partial-success-color;
   }
 }
 

--- a/app/assets/translations/ar.yml
+++ b/app/assets/translations/ar.yml
@@ -20,6 +20,8 @@ homepage:
   chart_title_two: 'الحالة'
   chart_two_label: 'في الميعاد'
   chart_two_label2: 'متأخر'
+  chart_two_label3: 'Extended'
+
 
   other_indicators_title: 'مؤشرات الأخرى'
   other_indicators_description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse ut augue aliquet ligula aliquam. Lorem ipsum dolor sit amet, consectetur elit.

--- a/app/assets/translations/en.yml
+++ b/app/assets/translations/en.yml
@@ -20,6 +20,7 @@ homepage:
   chart_title_two: Status
   chart_two_label: On Time
   chart_two_label2: Delayed
+  chart_two_label3: 'Extended'
 
   other_indicators_title: Other Progress Indicators
   other_indicators_description: Map and chart development indicators related to poverty and food and nutrition security in Egypt. Overlay agriculture and rural development projects in areas of interest.


### PR DESCRIPTION
close #242 @ascalamogna or @felskia, this adds the "extended" class to the homepage pie crust, and recolors the sections to match the indicator icons used elsewhere. Feel free to experiment with the legend colors (they had been previously been monochrome). They're styled in _charts.sccs: the slices are classes prefixed with `.pie__slice__`, and the bullets are :before selectors prefixed with `status-`.