### PR TITLE
Eliminate redundancy in config settings

### DIFF
--- a/app/assets/scripts/config.js
+++ b/app/assets/scripts/config.js
@@ -1,5 +1,5 @@
 'use strict';
-import { defaultsDeep } from 'lodash';
+import { clone, defaultsDeep } from 'lodash';
 
 /*
  * App configuration.
@@ -20,16 +20,13 @@ import { defaultsDeep } from 'lodash';
  *      polluting the repo.
  */
 
-import local from './config/local';
-import staging from './config/staging';
+import base from './config/base';
 import develop from './config/develop';
 import production from './config/production';
 
-var config = local || {};
+const config = clone(base);
 
-if (process.env.DS_ENV === 'staging') {
-  defaultsDeep(config, staging);
-} else if (process.env.DS_ENV === 'development') {
+if (process.env.DS_ENV === 'development') {
   defaultsDeep(config, develop);
 } else {
   defaultsDeep(config, production);

--- a/app/assets/scripts/config/base.js
+++ b/app/assets/scripts/config/base.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  api: 'https://ifpri-egypt-silo.herokuapp.com/',
+  authDomain: 'map-egypt.auth0.com',
+  authClientId: 'ZCoeGvXrh2Ex0x2UtCnnZ89wgUEMURRA'
+};

--- a/app/assets/scripts/config/develop.js
+++ b/app/assets/scripts/config/develop.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = {
-  environment: 'production',
-  api: 'https://ifpri-egypt-silo.herokuapp.com/',
-  baseUrl: 'http://localhost:3000'
+  environment: 'development',
+  baseUrl: 'http://localhost:3000/'
 };

--- a/app/assets/scripts/config/production.js
+++ b/app/assets/scripts/config/production.js
@@ -2,8 +2,5 @@
 
 module.exports = {
   environment: 'production',
-  api: 'https://ifpri-egypt-silo.herokuapp.com/',
-  baseUrl: 'https://map-egypt.github.io/',
-  authDomain: 'map-egypt.auth0.com',
-  authClientId: 'ZCoeGvXrh2Ex0x2UtCnnZ89wgUEMURRA'
+  baseUrl: 'https://map-egypt.github.io/'
 };

--- a/app/assets/scripts/config/staging.js
+++ b/app/assets/scripts/config/staging.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  environment: 'staging'
-};


### PR DESCRIPTION
Remove `config/local.js` as we're not storing anything sensitive and it causes issues. Store redundant config properties in `config/base.js` and only leave whatever's different in `develop` and `production`. Also remove `staging` as we're not using it for anything.