### PR TITLE
Fix translation issues

### DIFF
--- a/app/assets/scripts/components/project-card.js
+++ b/app/assets/scripts/components/project-card.js
@@ -7,6 +7,7 @@ import { parseProjectDate } from '../utils/date';
 import slugify from '../utils/slugify';
 import { tally, shortTally, pct, shortParagraph, ontimeLookup, currency } from '../utils/format';
 import getLocation from '../utils/location';
+import { getProjectName, getDescription } from '../utils/accessors';
 
 function categoryLink (base, categoryName) {
   return path.resolve(base, 'category', slugify(categoryName));
@@ -78,7 +79,7 @@ var ProjectCard = React.createClass({
         <article className={statusClass}>
           <div className='card__contents'>
             <header className='card__header'>
-              <h1 className='card__title heading--xsmall'><Link to={path.resolve(basepath, 'projects', project.id)} className='link--deco' href=''>{project.name}</Link></h1>
+              <h1 className='card__title heading--xsmall'><Link to={path.resolve(basepath, 'projects', project.id)} className='link--deco' href=''>{getProjectName(project, lang)}</Link></h1>
 
               {completion && (
                 <ul className='card-cmplt'>
@@ -93,7 +94,7 @@ var ProjectCard = React.createClass({
                 <dt className='card-meta__label'>Location</dt>
                 <dd className='card-meta__value card-meta__value--location'>{projects.join(', ')}</dd>
               </dl>
-              <p>{shortParagraph(project.description)}</p>
+              <p>{shortParagraph(getDescription(project, lang))}</p>
               <div className='card__categories'>
                 {project.categories.map((c, i) => {
                   let key = c.en;

--- a/app/assets/scripts/components/project-list.js
+++ b/app/assets/scripts/components/project-list.js
@@ -33,8 +33,8 @@ const ProjectList = React.createClass({
 
   render: function () {
     const { lang } = this.props;
-    const {projects, meta} = this.props;
-    const {sortAccessor} = this.state;
+    const { projects, meta } = this.props;
+    const { sortAccessor } = this.state;
     const data = projects.slice().sort((a, b) => sortAccessor(a) < sortAccessor(b) ? -1 : 1);
 
     const t = get(window.t, [lang, 'projects_list_view'], {});

--- a/app/assets/scripts/utils/accessors.js
+++ b/app/assets/scripts/utils/accessors.js
@@ -1,0 +1,25 @@
+'use strict';
+
+export const getDonorName = function (donor, lang) {
+  if (lang === 'ar' && donor.donor_name_ar) {
+    return donor.donor_name_ar;
+  } else {
+    return donor.donor_name;
+  }
+};
+
+export const getProjectName = function (project, lang) {
+  if (lang === 'ar' && project.name_ar) {
+    return project.name_ar;
+  } else {
+    return project.name;
+  }
+};
+
+export const getDescription = function (project, lang) {
+  if (lang === 'ar' && project.description_ar) {
+    return project.description_ar;
+  } else {
+    return project.description;
+  }
+};

--- a/app/assets/scripts/views/category.js
+++ b/app/assets/scripts/views/category.js
@@ -13,6 +13,7 @@ import { tally, shortTally, pct, shortText, currency } from '../utils/format';
 import slugify from '../utils/slugify';
 import { getProjectCentroids, getFeatureCollection } from '../utils/map-utils';
 import { window } from 'global';
+import { getProjectName } from '../utils/accessors';
 
 const chartMargin = { left: 150, right: 20, top: 10, bottom: 50 };
 
@@ -58,7 +59,7 @@ var Category = React.createClass({
 
     const numProjectsChartData = Object.keys(numProjectsPerCategory).map((key) => {
       return {
-        name: key,
+        name: get(categoryNames, [key, lang]),
         link: path.resolve(basepath, 'category', slugify(key)),
         value: numProjectsPerCategory[key]
       };
@@ -66,7 +67,7 @@ var Category = React.createClass({
 
     const budgetPerCategoryChartData = Object.keys(budgetPerCategory).map((key) => {
       return {
-        name: key,
+        name: get(categoryNames, [key, lang]),
         link: path.resolve(basepath, 'category', slugify(key)),
         value: budgetPerCategory[key]
       };
@@ -90,12 +91,8 @@ var Category = React.createClass({
     const markers = getProjectCentroids(categoryProjects, this.props.api.geography);
     const mapLocation = getFeatureCollection(markers);
 
-    const categoryBudgets = categoryProjects
-      .map((project) => project.budget)
-      .reduce((a, b) => a.concat(b), []);
-
     const chartData = categoryProjects.map((project) => ({
-      name: project.name,
+      name: getProjectName(project, lang),
       link: path.resolve(basepath, 'projects', project.id),
       value: project.budget.reduce((cur, item) => cur + item.fund.amount, 0),
       project
@@ -107,7 +104,10 @@ var Category = React.createClass({
       value: ProjectCard.percentComplete(d.project)
     }));
 
-    const totalBudget = categoryBudgets.reduce((currentValue, budget) => {
+    const totalBudget = categoryProjects
+    .map((project) => project.budget)
+    .reduce((a, b) => a.concat(b), [])
+    .reduce((currentValue, budget) => {
       return budget.fund.amount + currentValue;
     }, 0);
 

--- a/app/assets/scripts/views/donor.js
+++ b/app/assets/scripts/views/donor.js
@@ -29,20 +29,21 @@ var Donor = React.createClass({
     if (projects.length === 0) {
       return <div></div>; // TODO loading indicator
     }
-    const basepath = '/' + this.props.meta.lang;
-
+    const { lang } = this.props.meta;
+    const basepath = '/' + lang;
     const donorName = this.props.params.name;
-    let donorDisplayName;
-
+    let donorMeta;
     const donorProjects = projects.filter((project) => {
       return get(project, 'budget', []).some((item) => {
+        console.log(item);
         let sluggedName = slugify(item.donor_name);
         if (sluggedName === donorName) {
-          donorDisplayName = item.donor_name;
+          donorMeta = item;
         }
         return sluggedName === donorName;
       });
     });
+    const donorDisplayName = lang === 'ar' ? donorMeta.donor_name_ar : donorMeta.donor_name;
 
     const markers = getProjectCentroids(donorProjects, this.props.api.geography);
     const mapLocation = getFeatureCollection(markers);
@@ -64,8 +65,6 @@ var Donor = React.createClass({
       return budget.fund.amount + currentValue;
     }, 0);
 
-    const { lang } = this.props.meta;
-
     const csvSummary = {
       title: 'Donor Summary',
       data: {
@@ -82,7 +81,7 @@ var Donor = React.createClass({
     ];
 
     const singleProject = donorProjects.length <= 1 ? ' funding--single' : '';
-    const t = get(window.t, [this.props.meta.lang, 'donor_pages'], {});
+    const t = get(window.t, [lang, 'donor_pages'], {});
     return (
       <section className='inpage funding'>
         <header className='inpage__header'>
@@ -96,8 +95,8 @@ var Donor = React.createClass({
                     summary={csvSummary}
                     chartData={csvChartData}
                     lang={lang} /></li>
-                  <li><Print lang={this.props.meta.lang} /></li>
-                  <li><Share path={this.props.location.pathname} lang={this.props.meta.lang}/></li>
+                  <li><Print lang={lang} /></li>
+                  <li><Share path={this.props.location.pathname} lang={lang}/></li>
                 </ul>
               </div>
               <h1 className='inpage__title heading--deco heading--large'>{donorDisplayName}</h1>
@@ -121,7 +120,7 @@ var Donor = React.createClass({
                   <div className='inpage__overview-chart'>
                     <div className='chart-content'>
                     <HorizontalBarChart
-                      lang={this.props.meta.lang}
+                      lang={lang}
                       data={chartData}
                       margin={{ left: 130, right: 50, top: 10, bottom: 50 }}
                       xFormat={shortTally}
@@ -140,7 +139,7 @@ var Donor = React.createClass({
                 {donorProjects.map((p) => {
                   return (
                     <li key={p.id} className='projects-list__card'>
-                      <ProjectCard lang={this.props.meta.lang}
+                      <ProjectCard lang={lang}
                         project={p} />
                     </li>
                   );

--- a/app/assets/scripts/views/owner.js
+++ b/app/assets/scripts/views/owner.js
@@ -12,6 +12,7 @@ import HorizontalBarChart from '../components/charts/horizontal-bar';
 import { shortTally, shortText } from '../utils/format';
 import { getProjectCentroids, getFeatureCollection } from '../utils/map-utils';
 import slugify from '../utils/slugify';
+import { getProjectName } from '../utils/accessors';
 
 var Owner = React.createClass({
   displayName: 'Owner',
@@ -29,28 +30,17 @@ var Owner = React.createClass({
       return <div></div>; // TODO loading indicator
     }
     const basepath = '/' + this.props.meta.lang;
-
     const ownerName = this.props.params.name;
-    let ownerDisplayName;
-
+    const ownerProjects = projects.filter(project => project.local_manager && ownerName === slugify(project.local_manager));
     const lang = this.props.meta.lang;
-    const ownerProjects = projects.filter((project) => {
-      let name = project.local_manager;
-      if (name) {
-        const sluggedName = slugify(name);
-        if (sluggedName === ownerName) {
-          ownerDisplayName = name;
-        }
-        return sluggedName === ownerName;
-      }
-    });
+    const ownerDisplayName = lang === 'ar' ? get(ownerProjects, '0.local_manager_ar') : get(ownerProjects, '0.local_manager');
 
     const markers = getProjectCentroids(ownerProjects, this.props.api.geography);
     const mapLocation = getFeatureCollection(markers);
 
     const chartData = ownerProjects.map((project) => {
       return {
-        name: project.name,
+        name: getProjectName(project, lang),
         link: path.resolve(basepath, 'projects', project.id),
         value: project.number_served.number_served
       };

--- a/app/assets/scripts/views/project.js
+++ b/app/assets/scripts/views/project.js
@@ -124,7 +124,7 @@ var Project = React.createClass({
 
     const donors = get(data, 'budget', []).map((donor) => ({
       name: getDonorName(donor, lang),
-      link: path.resolve(basepath, 'donor', slugify(donor.donor_name)),
+      link: linkPath(basepath, 'donor', donor.donor_name),
       value: donor.fund.amount
     })).sort((a, b) => b.value > a.value ? -1 : 1);
 
@@ -214,7 +214,7 @@ var Project = React.createClass({
                 <p className='tags__label'>{t.donors_title}:</p>
                 <div className='inpage__subtitles'>
                   {donors.map((donor) => <span key={donor.name} className='inpage__subtitle'>
-                      <Link to={linkPath(basepath, 'donor', donor.name)} className='link--secondary' href=''>{donor.name}</Link>&nbsp;
+                      <Link to={donor.link} className='link--secondary' href=''>{donor.name}</Link>&nbsp;
                     </span>)}
                 </div>
               </div>

--- a/app/assets/scripts/views/project.js
+++ b/app/assets/scripts/views/project.js
@@ -416,7 +416,7 @@ var Project = React.createClass({
                   yTitle=''
                   xFormat={shortTally}
                   yFormat={shortText}
-                  activeProject={meta.name}
+                  activeProject={projectDisplayName}
                 />
               </div>
               <div className='chart-content chart__inline--labels'>
@@ -428,7 +428,7 @@ var Project = React.createClass({
                   yTitle=''
                   xFormat={pct}
                   yFormat={shortText}
-                  activeProject={meta.name}
+                  activeProject={projectDisplayName}
                 />
               </div>
               {authenticated ? (
@@ -441,7 +441,7 @@ var Project = React.createClass({
                     yTitle=''
                     xFormat={tally}
                     yFormat={shortText}
-                    activeProject={meta.name}
+                    activeProject={projectDisplayName}
                   />
                 </div>
               ) : null}

--- a/app/assets/scripts/views/project.js
+++ b/app/assets/scripts/views/project.js
@@ -137,7 +137,7 @@ var Project = React.createClass({
       value: d.value
     }));
 
-    const t = get(window.t, [this.props.meta.lang, 'project_pages'], {});
+    const t = get(window.t, [lang, 'project_pages'], {});
 
     const csvChartData = [
       {
@@ -165,6 +165,8 @@ var Project = React.createClass({
       });
     }
 
+    const localManager = lang === 'ar' ? data.local_manager_ar : data.local_manager;
+
     return (
       <section className='inpage'>
         <header className='inpage__header'>
@@ -177,9 +179,9 @@ var Project = React.createClass({
                       relatedProjects={relatedProjects}
                       project={data}
                       chartData={csvChartData}
-                      lang={this.props.meta.lang} /></li>
-                  <li><Print lang={this.props.meta.lang} /></li>
-                  <li><Share path={this.props.location.pathname} lang={this.props.meta.lang}/></li>
+                      lang={lang} /></li>
+                  <li><Print lang={lang} /></li>
+                  <li><Share path={this.props.location.pathname} lang={lang}/></li>
                 </ul>
               </div>
               <dl className={'inpage-meta project--' + ontime}>
@@ -192,7 +194,7 @@ var Project = React.createClass({
               </dl>
               <h1 className='inpage__title heading--deco heading--large'>{meta.name}</h1>
             </div>
-            <ProjectTimeline project={data} lang={this.props.meta.lang}/>
+            <ProjectTimeline project={data} lang={lang}/>
 
             <div className='tags'>
               <div className='tags__group'>
@@ -274,16 +276,16 @@ var Project = React.createClass({
                   <div className='overview-item'>
                     <h2 className='overview-item__title heading-alt'>{t.responsible_ministry_title}</h2>
                     <ul className='link-list'>
-                      <li><a href={`#/${lang}/ministry/${slugify(data.responsible_ministry[lang])}`} className='link--primary'><span>{data.responsible_ministry[lang]}</span></a></li>
+                      <li><a href={`#/${lang}/ministry/${slugify(data.responsible_ministry.en)}`} className='link--primary'><span>{data.responsible_ministry[lang]}</span></a></li>
                     </ul>
                   </div>
                 )}
 
-                {((lang === 'en' && data.local_manager) || lang === 'ar' && data.local_manager_ar) && (
+                {localManager && (
                   <div className='overview-item'>
                     <h2 className='overview-item__title heading-alt'>{t.local_manager_title}</h2>
                     <ul className='link-list'>
-                      <li><a href={`#/${lang}/owner/${slugify(data.local_manager)}`} className='link--primary'><span>{lang === 'en' ? data.local_manager : data.local_manager_ar}</span></a></li>
+                      <li><a href={`#/${lang}/owner/${slugify(data.local_manager)}`} className='link--primary'><span>{localManager}</span></a></li>
                     </ul>
                   </div>
                 )}
@@ -342,7 +344,7 @@ var Project = React.createClass({
                 <div className={'chart-content chart__inline--labels' + (!authenticated ? ' chart__block' : '')}>
                   <h3>{t.funding_by_donor_title}</h3>
                   <HorizontalBarChart
-                    lang={this.props.meta.lang}
+                    lang={lang}
                     data={donors}
                     margin={barChartMargin}
                     yTitle=''
@@ -357,7 +359,7 @@ var Project = React.createClass({
                       margin={barChartMargin}
                       yTitle=''
                       xFormat={shortTally}
-                      lang={this.props.meta.lang}
+                      lang={lang}
                     />
                   </div>
                 ) : null}
@@ -403,7 +405,7 @@ var Project = React.createClass({
               <div className='chart-content chart__inline--labels'>
                 <h3>{t.comparison_chart_title1}</h3>
                 <HorizontalBarChart
-                  lang={this.props.meta.lang}
+                  lang={lang}
                   data={budgets}
                   margin={barChartMargin}
                   yTitle=''
@@ -415,7 +417,7 @@ var Project = React.createClass({
               <div className='chart-content chart__inline--labels'>
                 <h3>{t.comparison_chart_title2}</h3>
                 <HorizontalBarChart
-                  lang={this.props.meta.lang}
+                  lang={lang}
                   data={completion}
                   margin={barChartMargin}
                   yTitle=''
@@ -428,7 +430,7 @@ var Project = React.createClass({
                 <div className='chart-content chart__inline--labels'>
                   <h3>{t.comparision_chart_title3}</h3>
                   <HorizontalBarChart
-                    lang={this.props.meta.lang}
+                    lang={lang}
                     data={served}
                     margin={barChartMargin}
                     yTitle=''
@@ -449,7 +451,7 @@ var Project = React.createClass({
                     <li key={p.id}
                       className='projects-list__card'>
                       <ProjectCard
-                        lang={this.props.meta.lang}
+                        lang={lang}
                         project={p}
                       />
                     </li>

--- a/app/assets/scripts/views/project.js
+++ b/app/assets/scripts/views/project.js
@@ -164,6 +164,7 @@ var Project = React.createClass({
     const projectDisplayName = isArabic ? data.name_ar : data.name;
     const localManager = isArabic ? data.local_manager_ar : data.local_manager;
     const description = isArabic ? data.description_ar : data.description;
+    const servedUnits = isArabic ? data.number_served.number_served_unit_ar : data.number_served.number_served_unit;
 
     return (
       <section className='inpage'>
@@ -227,7 +228,7 @@ var Project = React.createClass({
               <div className='inpage__col--content'>
                 <ul className='inpage-stats'>
                   <li>{currency(shortTally(budget))} <small>{t.funding_title}</small></li>
-                  <li>{tally(data.number_served.number_served)} <small>{data.number_served.number_served_unit}</small></li>
+                  <li>{tally(data.number_served.number_served)} <small>{servedUnits}</small></li>
                 </ul>
                 {disbursedFunds.loan || disbursedFunds.grant
                   ? <ul className='inpage-stats'>

--- a/app/assets/styles/core/_rtl.scss
+++ b/app/assets/styles/core/_rtl.scss
@@ -544,10 +544,6 @@
     }
   }
 
-  .chart-content {
-    float: right;
-  }
-
   .indicator-list-container {
   .chart-container {
     float: right;


### PR DESCRIPTION
Close #284 

1. Ministry links work on both languages
2. Owner/local manager shows up on both languages
3. Fix issue of some charts not rendering on Arabic
4. Summary items show the correct language

On the last point: some parts lower in the page (charts, project cards) will "fall back" to English if on Arabic pages and Arabic doesn't exit. These would look totally broken otherwise. But the top-level items (donor name, category name) will attempt to show the right language or show nothing.

This should give the admins a good indication of which items still need translations.