### PR TITLE
Fix progress bar length when future actual_end_date in record

### DIFF
--- a/app/assets/scripts/components/map.js
+++ b/app/assets/scripts/components/map.js
@@ -323,7 +323,6 @@ const Map = React.createClass({
   },
 
   render: function () {
-    // console.log(this.props.overlay)
     return (
       <div className='map__group'>
         <div className='map__container' ref={this.mountMap}></div>

--- a/app/assets/scripts/components/project-timeline.js
+++ b/app/assets/scripts/components/project-timeline.js
@@ -21,7 +21,7 @@ var ProjectTimeline = React.createClass({
     const plannedEnd = parseProjectDate(project.planned_end_date);
 
     const actualStart = project.actual_start_date ? parseProjectDate(project.actual_start_date) : null;
-    const actualEnd = project.actual_end_date
+    let actualEnd = project.actual_end_date && !(parseProjectDate(project.actual_end_date) > new Date().getTime())
       ? parseProjectDate(project.actual_end_date)
       : new Date().getTime();
 


### PR DESCRIPTION
close #310 This fix sets the end of the timeline to the current day, in cases where the recorded `actual_end_date` is in the future. Ideally, future `actual_end_date`s should also be removed from the database.