### PR TITLE
Show loans and grants to all users

### DIFF
--- a/app/assets/scripts/views/project.js
+++ b/app/assets/scripts/views/project.js
@@ -79,7 +79,7 @@ var Project = React.createClass({
     const lastUpdated = formatDate(meta.updated_at) || '';
     const budget = get(data, 'budget', []).reduce((a, b) => a + get(b, 'fund.amount', 0), 0);
 
-    const disbursedFunds = {loan: 0, grant: 0};
+    const disbursedFunds = {loan: 0, grant: 0, 'local contribution': 0};
     get(data, 'disbursed', []).forEach((fund) => {
       disbursedFunds[fund.type.en.toLowerCase()] += fund.fund.amount;
     });
@@ -165,7 +165,6 @@ var Project = React.createClass({
     const localManager = isArabic ? data.local_manager_ar : data.local_manager;
     const description = isArabic ? data.description_ar : data.description;
     const servedUnits = isArabic ? data.number_served.number_served_unit_ar : data.number_served.number_served_unit;
-
     return (
       <section className='inpage'>
         <header className='inpage__header'>
@@ -235,6 +234,7 @@ var Project = React.createClass({
                 <ul className='inpage-stats'>
                   <li>{currency(shortTally(disbursedFunds.loan))} <small>{t.funding_loans_title}</small></li>
                   <li>{currency(shortTally(disbursedFunds.grant))} <small>{t.funding_grants_title}</small></li>
+                  <li>{currency(shortTally(disbursedFunds['local contribution']))} <small>{t.funding_local_title}</small></li>
                 </ul>
                 <div className='inpage__overview-links'>
                 <h2 className='overview-item__title heading-alt'>{t.objective_title}</h2>

--- a/app/assets/scripts/views/project.js
+++ b/app/assets/scripts/views/project.js
@@ -232,16 +232,10 @@ var Project = React.createClass({
                   <li>{currency(shortTally(budget))} <small>{t.funding_title}</small></li>
                   <li>{tally(data.number_served.number_served)} <small>{servedUnits}</small></li>
                 </ul>
-                {disbursedFunds.loan || disbursedFunds.grant
-                  ? <ul className='inpage-stats'>
-                      {disbursedFunds.loan
-                        ? <li>{currency(shortTally(disbursedFunds.loan))} <small>{t.funding_loans_title}</small></li>
-                        : ''}
-                      {disbursedFunds.grant
-                        ? <li>{currency(shortTally(disbursedFunds.grant))} <small>{t.funding_grants_title}</small></li>
-                        : ''}
+                <ul className='inpage-stats'>
+                  <li>{currency(shortTally(disbursedFunds.loan))} <small>{t.funding_loans_title}</small></li>
+                  <li>{currency(shortTally(disbursedFunds.grant))} <small>{t.funding_grants_title}</small></li>
                 </ul>
-                  : ''}
                 <div className='inpage__overview-links'>
                 <h2 className='overview-item__title heading-alt'>{t.objective_title}</h2>
                 <ul>

--- a/app/assets/translations/ar.yml
+++ b/app/assets/translations/ar.yml
@@ -59,6 +59,7 @@ project_pages:
   funding_title: 'التمويل'
   funding_loans_title: 'قرض'
   funding_grants_title: 'منحة'
+  funding_local_title: 'قرضة'
   objective_title: 'الهدف'
   location_title: 'النطاق الجغرافي'
   project_link: 'الرابط الالكتروني للمشروع'

--- a/app/assets/translations/en.yml
+++ b/app/assets/translations/en.yml
@@ -58,6 +58,7 @@ project_pages:
   funding_title: Funding
   funding_loans_title: Loans
   funding_grants_title: Grants
+  funding_local_title: Local Contribution
   objective_title: Objective
   location_title: Location
   project_link: Project Link


### PR DESCRIPTION
Display loan and grant totals on project pages to all users, rather than only logged-in users (donor names are now scrubbed by the API). If no loans or grants are available, show $0 rather than hiding the item.