### PR TITLE
add CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+mapegypt.org


### PR DESCRIPTION
This file makes it so when the DNS settings are set to point to github (using this guide: https://help.github.com/articles/adding-or-removing-a-custom-domain-for-your-github-pages-site/), the site will work at mapegypt.org. 