### PR TITLE
Add other property

### DIFF
--- a/app/assets/scripts/views/project-browse.js
+++ b/app/assets/scripts/views/project-browse.js
@@ -365,7 +365,7 @@ var ProjectBrowse = React.createClass({
     indicators.forEach((indicator) => {
       indicator.theme.forEach((theme) => {
         if (theme.type === indicatorProp) {
-          let themeName = theme[lang];
+          let themeName = theme[lang] || 'Other';
           themes[themeName] = themes[themeName] || [];
           themes[themeName].push(indicator);
         }
@@ -419,7 +419,8 @@ var ProjectBrowse = React.createClass({
             </div>
             <div className='indicators--options'>
               {availableIndicators.length && availableIndicators.map((indicator) => {
-                const name = indicator.name;
+                const name = lang === 'en' ? indicator.name : indicator.name_ar;
+                if (!name) return null;
                 const id = 'subtypes-' + slugify(name);
 
                 return (
@@ -620,10 +621,10 @@ var ProjectBrowse = React.createClass({
                       {this.state.indicatorToggle &&
                         <ul className='drop__menu drop--align-left button--secondary'>
                           {indicatorTypes.map((d) => {
-                            d = t[d + '_dropdown'];
+                            let display = t[d + '_dropdown'];
                             return <li key={d}
                               onClick={() => this.openIndicatorSelector(d)}
-                              className='drop__menu-item'>{d}</li>;
+                              className='drop__menu-item'>{display}</li>;
                           })}
                         </ul>
                       }

--- a/app/assets/scripts/views/project-browse.js
+++ b/app/assets/scripts/views/project-browse.js
@@ -360,12 +360,13 @@ var ProjectBrowse = React.createClass({
     const indicators = get(this.props.api, 'indicators', []).filter((indicator) => {
       return indicator.theme.length && indicator.theme.find(d => d.type === indicatorProp);
     });
+    const t = get(window.t, [lang, 'projects_indicators'], {});
 
     const themes = {};
     indicators.forEach((indicator) => {
       indicator.theme.forEach((theme) => {
         if (theme.type === indicatorProp) {
-          let themeName = theme[lang] || 'Other';
+          let themeName = theme[lang] || t['other'];
           themes[themeName] = themes[themeName] || [];
           themes[themeName].push(indicator);
         }
@@ -386,7 +387,6 @@ var ProjectBrowse = React.createClass({
 
     const indicatorTheme = activeIndicatorTheme || themeNames[0];
     const availableIndicators = get(themes, indicatorTheme, []);
-    const t = get(window.t, [lang, 'projects_indicators'], {});
     return (
       <section className='modal modal--large'>
         <div className='modal__inner modal__indicators'>

--- a/app/assets/translations/ar.yml
+++ b/app/assets/translations/ar.yml
@@ -58,6 +58,7 @@ projects_indicators:
   all_projects: 'جميع المشاريع'
   reset_filters: 'إعادة التصفية'
   selected_overlays: 'المؤشرات المحددة'
+  other: Other
 
 projects_list_view:
   projects_title: 'المشروعات'

--- a/app/assets/translations/en.yml
+++ b/app/assets/translations/en.yml
@@ -58,6 +58,7 @@ projects_indicators:
   all_projects: All Projects
   reset_filters: reset filters
   selected_overlays: Selected Indicator Overlays
+  other: Other
 
 projects_list_view:
   projects_title: Projects


### PR DESCRIPTION
Adds 'other' property for indicators to fall into if they don't have an arabic translation. The 'Other' text is in both translations files (it's in English in the Arabic file though).

![screen shot 2017-10-19 at 1 32 10 pm](https://user-images.githubusercontent.com/1590802/31785125-30c40cc0-b4d2-11e7-93f8-b557ec6cf26b.png)
