### PR TITLE
Replace object path with defaults

### DIFF
--- a/app/assets/scripts/components/project-card.js
+++ b/app/assets/scripts/components/project-card.js
@@ -74,7 +74,7 @@ var ProjectCard = React.createClass({
     const funding = budget.reduce((a, b) => a + b.fund.amount, 0);
     let completion = pct(percentComplete(project));
     let projects = [];
-    let locations = project.location || []
+    let locations = project.location || [];
     locations.map((loc, i) => {
       const location = getLocation(loc, lang);
       if (location) {

--- a/app/assets/scripts/components/project-card.js
+++ b/app/assets/scripts/components/project-card.js
@@ -70,10 +70,12 @@ var ProjectCard = React.createClass({
     const ontime = isOntime(project);
     const statusClass = 'project--' + ontime;
     const basepath = '/' + lang;
-    const funding = get(project, 'budget', []).reduce((a, b) => a + b.fund.amount, 0);
+    const budget = project.budget || [];
+    const funding = budget.reduce((a, b) => a + b.fund.amount, 0);
     let completion = pct(percentComplete(project));
     let projects = [];
-    get(project, 'location', []).map((loc, i) => {
+    let locations = project.location || []
+    locations.map((loc, i) => {
       const location = getLocation(loc, lang);
       if (location) {
         projects.push(location.display);

--- a/app/assets/scripts/utils/map-utils.js
+++ b/app/assets/scripts/utils/map-utils.js
@@ -28,7 +28,7 @@ export const getProjectCentroids = function (projects, features) {
 
   const regions = {};
   projects.forEach(function (project) {
-    project.location = project.location || []
+    project.location = project.location || [];
     get(project, 'location', []).forEach(function (location) {
       const isDistrict = hasDistrictData(location);
       const id = isDistrict ? location.district.district : location.district.governorate;

--- a/app/assets/scripts/utils/map-utils.js
+++ b/app/assets/scripts/utils/map-utils.js
@@ -28,6 +28,7 @@ export const getProjectCentroids = function (projects, features) {
 
   const regions = {};
   projects.forEach(function (project) {
+    project.location = project.location || []
     get(project, 'location', []).forEach(function (location) {
       const isDistrict = hasDistrictData(location);
       const id = isDistrict ? location.district.district : location.district.governorate;

--- a/app/assets/scripts/utils/slugify.js
+++ b/app/assets/scripts/utils/slugify.js
@@ -1,5 +1,6 @@
 'use strict';
 module.exports = function slugify (text) {
+  text = text || ''
   return text.toString().toLowerCase()
   .replace(/\s+/g, '-')           // Replace spaces with -
   .replace(/[^\w\-]+/g, '')       // Remove all non-word chars

--- a/app/assets/scripts/utils/slugify.js
+++ b/app/assets/scripts/utils/slugify.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = function slugify (text) {
-  text = text || ''
+  text = text || '';
   return text.toString().toLowerCase()
   .replace(/\s+/g, '-')           // Replace spaces with -
   .replace(/[^\w\-]+/g, '')       // Remove all non-word chars

--- a/app/assets/scripts/views/category.js
+++ b/app/assets/scripts/views/category.js
@@ -39,7 +39,8 @@ var Category = React.createClass({
     const categoryNames = {};
     // Count number of projects per category
     const justCategories = projects.map((project) => {
-      let budget = project.budget.reduce((cur, item) => cur + get(item, 'fund.amount', 0), 0);
+      let budgets = project.budget || [];
+      let budget = budgets.reduce((cur, item) => cur + get(item, 'fund.amount', 0), 0);
       return get(project, 'categories', []).map((category) => {
         let key = category.en;
         categoryNames[key] = category;

--- a/app/assets/scripts/views/home.js
+++ b/app/assets/scripts/views/home.js
@@ -61,14 +61,16 @@ var Home = React.createClass({
     const collaborations = [];
     let collaborationCount = 0;
     projects.forEach((project) => {
-      let collaborators = project.budget.filter((b) => {
+      let budgets = project.budget || []
+      let collaborators = budgets.filter((b) => {
         return b.donor_name !== 'MoALR / Government of Egypt contribution' && b.donor_name !== 'Government of Egypt' && b.donor_name !== 'Project Beneficiaries';
       });
       if (collaborators.length > 1) {
         collaborators.forEach((c) => collaborations.push(c.donor_name));
         collaborationCount += 1;
       }
-      project.budget.forEach((budget) => {
+      let budgets = project.budget || []
+      budgets.forEach((budget) => {
         totalDonors[budget.donor_name] = '';
         totalFunding += budget.fund.amount;
       });
@@ -90,7 +92,8 @@ var Home = React.createClass({
 
     let budgetSummary = {loan: 0, grant: 0, 'local contribution': 0};
     projects.forEach((project) => {
-      get(project, 'budget', []).forEach((fund) => {
+      let budgets = project.budget || [];
+      budgets.forEach((fund) => {
         budgetSummary[fund.type.en.toLowerCase()] += fund.fund.amount;
       });
     });

--- a/app/assets/scripts/views/home.js
+++ b/app/assets/scripts/views/home.js
@@ -61,7 +61,7 @@ var Home = React.createClass({
     const collaborations = [];
     let collaborationCount = 0;
     projects.forEach((project) => {
-      let budgets = project.budget || []
+      let budgets = project.budget || [];
       let collaborators = budgets.filter((b) => {
         return b.donor_name !== 'MoALR / Government of Egypt contribution' && b.donor_name !== 'Government of Egypt' && b.donor_name !== 'Project Beneficiaries';
       });
@@ -69,7 +69,6 @@ var Home = React.createClass({
         collaborators.forEach((c) => collaborations.push(c.donor_name));
         collaborationCount += 1;
       }
-      let budgets = project.budget || []
       budgets.forEach((budget) => {
         totalDonors[budget.donor_name] = '';
         totalFunding += budget.fund.amount;

--- a/app/assets/scripts/views/project.js
+++ b/app/assets/scripts/views/project.js
@@ -105,7 +105,7 @@ var Project = React.createClass({
     // so don't do any more sorting after the budget map.
     const budgets = allProjects.map((project) => ({
       name: getProjectName(project, lang),
-      value: get(project, 'budget', []).reduce((a, b) => a + get(b, 'fund.amount', 0), 0),
+      value: project.budget ? get(project, 'budget', []).reduce((a, b) => a + get(b, 'fund.amount', 0), 0) : 0,
       link: path.resolve(basepath, 'projects', project.id),
       project: project
     })).sort((a, b) => b.value > a.value ? -1 : 1);


### PR DESCRIPTION
object-path.get is throwing errors instead of setting default on some
pages. We replace object-path.get with basic default setting using
short-circuiting.

Closed #370 